### PR TITLE
fix(frontend): use env or location for callback URL

### DIFF
--- a/packages/repco-frontend/app/services/auth.server.ts
+++ b/packages/repco-frontend/app/services/auth.server.ts
@@ -2,6 +2,12 @@ import { Authenticator } from 'remix-auth'
 import { GitHubStrategy, SocialsProvider } from 'remix-auth-socials'
 import { sessionStorage } from './session.server'
 
+const BASE_URL = process.env.BASE_URL || window.location.origin
+const CALLBACK_URL =
+  BASE_URL + BASE_URL.endsWith('/')
+    ? ''
+    : '/' + SocialsProvider.GITHUB + '/callback'
+
 export const authenticator = new Authenticator(sessionStorage, {
   sessionKey: '_session',
 })
@@ -25,8 +31,7 @@ authenticator.use(
     {
       clientID: process.env.GITHUB_CLIENT_ID || '',
       clientSecret: process.env.GITHUB_CLIENT_SECRET || '',
-      callbackURL:
-        'http://localhost:3000/auth/' + SocialsProvider.GITHUB + '/callback',
+      callbackURL: CALLBACK_URL
     },
     handleSocialAuthCallback,
   ),


### PR DESCRIPTION
GitHub login is not working on deployed setup. Callback URL was statically set to localhost. Now it uses either a `BASE_URL` env variable or `window.location.origin`.