### PR TITLE
[WIP] Datasources fixing

### DIFF
--- a/packages/repco-core/src/datasources/cba.ts
+++ b/packages/repco-core/src/datasources/cba.ts
@@ -37,11 +37,11 @@ import {
   DataSourceDefinition,
   DataSourcePlugin,
   FetchUpdatesResult,
+  log,
   SourceRecordForm,
 } from '../datasource.js'
 import { ConceptKind, ContentGroupingVariant, EntityForm } from '../entity.js'
 import { FetchOpts } from '../util/datamapping.js'
-import { log } from '../datasource.js'
 import { HttpError } from '../util/error.js'
 
 // Endpoint of the Datasource
@@ -118,96 +118,38 @@ export class CbaDataSource implements DataSource {
 
   async fetchByUri(uri: string): Promise<SourceRecordForm[]> {
     const parsed = this.parseUri(uri)
-    if (!parsed) throw new Error('Invalid URI')
-    switch (parsed.type) {
-      case 'post': {
-        const url = this._url(`/post/${parsed.id}`)
-        const post = await this._fetch<CbaPost>(url)
-        this.expandAttachements(post)
-        return [
-          {
-            body: JSON.stringify(post),
-            contentType: CONTENT_TYPE_JSON,
-            sourceType: 'post',
-            sourceUri: url,
-          },
-        ]
-      }
-      case 'audio': {
-        const url = this._url(`/media/${parsed.id}`)
-        const body = await this._fetch(url)
-        return [
-          {
-            body: JSON.stringify(body),
-            contentType: CONTENT_TYPE_JSON,
-            sourceType: 'audio',
-            sourceUri: url,
-          },
-        ]
-      }
-      case 'image': {
-        const url = this._url(`/media/${parsed.id}`)
-        const body = await this._fetch(url)
-        return [
-          {
-            body: JSON.stringify(body),
-            contentType: CONTENT_TYPE_JSON,
-            sourceType: 'image',
-            sourceUri: url,
-          },
-        ]
-      }
-      case 'series': {
-        const url = this._url(`/series/${parsed.id}`)
-        const body = await this._fetch(url)
-        return [
-          {
-            body: JSON.stringify(body),
-            contentType: CONTENT_TYPE_JSON,
-            sourceType: 'series',
-            sourceUri: url,
-          },
-        ]
-      }
-      case 'category': {
-        const url = this._url(`/categories/${parsed.id}`)
-        const body = await this._fetch(url)
-        return [
-          {
-            body: JSON.stringify(body),
-            contentType: CONTENT_TYPE_JSON,
-            sourceType: 'category',
-            sourceUri: url,
-          },
-        ]
-      }
-      case 'tag': {
-        const url = this._url(`/tags/${parsed.id}`)
-        const body = await this._fetch(url)
-        return [
-          {
-            body: JSON.stringify(body),
-            contentType: CONTENT_TYPE_JSON,
-            sourceType: 'tag',
-            sourceUri: url,
-          },
-        ]
-      }
-      case 'station': {
-        //Radiostation
-        const url = this._url(`/station/${parsed.id}`)
-        const body = await this._fetch(url)
-        return [
-          {
-            body: JSON.stringify(body),
-            contentType: CONTENT_TYPE_JSON,
-            sourceType: 'station',
-            sourceUri: url,
-          },
-        ]
-      }
+    if (!parsed) {
+      throw new Error('Invalid URI')
     }
-    throw new Error('Unsupported CBA data type: ' + parsed.type)
+
+    const endpointMap: { [key: string]: string } = {
+      post: 'post',
+      audio: 'media',
+      image: 'media',
+      series: 'series',
+      category: 'categories',
+      tag: 'tags',
+      station: 'station',
+    }
+
+    const { id, type } = parsed
+    const endpoint = endpointMap[type]
+
+    if (!endpoint) {
+      throw new Error('Unsupported CBA data type: ' + parsed.type)
+    }
+
+    const url = this._url(`/${endpoint}/${id}`)
+    const [body] = await Promise.all([this._fetch(url)])
+
+    return [
+      {
+        body: JSON.stringify(body),
+        contentType: CONTENT_TYPE_JSON,
+        sourceType: type,
+        sourceUri: url,
+      },
+    ]
   }
 
   /**
@@ -215,43 +157,57 @@ export class CbaDataSource implements DataSource {
    *
    * @param post The post for which to expand the attachment links.
    */
-  async expandAttachements(post: CbaPost) {
-    post._fetchedAttachements = []
-    const fetchedAttachements = await Promise.all(
-      post._links['wp:attachment'].map(async (attachement) => {
-        const { href } = attachement
-        const medias = await this._fetch(href)
-        return medias
-      }),
+  async expandAttachments(post: CbaPost) {
+    const attachmentLinks = post._links['wp:attachment']
+    if (!attachmentLinks || attachmentLinks.length === 0) {
+      return
+    }
+
+    const attachmentPromises = attachmentLinks.map((attachment) =>
+      this._fetch(attachment.href),
     )
-    post._fetchedAttachements = fetchedAttachements.flat()
+    const attachments = await Promise.all(attachmentPromises)
+    post._fetchedAttachements = attachments.flat()
   }
 
   async fetchUpdates(cursorString: string | null): Promise<FetchUpdatesResult> {
-    const cursor = cursorString ? JSON.parse(cursorString) : {}
-    const records = []
-    {
-      let postsCursor = cursor.posts
-      if (!postsCursor) postsCursor = '1970-01-01T01:00:00'
+    try {
+      const cursor = cursorString ? JSON.parse(cursorString) : {}
+      const { posts: postsCursor = '1970-01-01T01:00:00' } = cursor
       const perPage = 100
       const url = this._url(
         `/posts?page=1&per_page=${perPage}&_embed&orderby=modified&order=asc&modified_after=${postsCursor}`,
       )
       const posts = await this._fetch<CbaPost[]>(url)
-      await Promise.all(posts.map((post) => this.expandAttachements(post)))
 
-      const lastPost = posts[posts.length - 1]
-      if (lastPost) cursor.posts = lastPost.modified
-      records.push({
-        body: JSON.stringify(posts),
-        contentType: CONTENT_TYPE_JSON,
-        sourceType: 'posts',
-        sourceUri: url,
-      })
-    }
-    return {
-      cursor: JSON.stringify(cursor),
-      records,
+      await Promise.all(
+        posts.map(async (post) => {
+          try {
+            await this.expandAttachments(post)
+          } catch (error) {
+            console.error(
+              `Error expanding attachments for post ${post.id}: ${error}`,
+            )
+          }
+        }),
+      )
+
+      cursor.posts = posts?.[posts.length - 1]?.modified || cursor.posts
+
+      return {
+        cursor: JSON.stringify(cursor),
+        records: [
+          {
+            body: JSON.stringify(posts),
+            contentType: CONTENT_TYPE_JSON,
+            sourceType: 'posts',
+            sourceUri: url,
+          },
+        ],
+      }
+    } catch (error) {
+      console.error(`Error fetching updates: ${error}`)
+      throw error
     }
   }
 
@@ -321,6 +277,14 @@ export class CbaDataSource implements DataSource {
     const fileId = this._uri('file', media.id)
     const audioId = this._uri('audio', media.id)
 
+    if (!media.source_url) {
+      throw new Error('Media source URL is missing.')
+    }
+
+    if (!media.media_details) {
+      throw new Error('Media details are missing.')
+    }
+
     const file: form.FileInput = {
       contentUrl: media.source_url,
       bitrate: media.media_details.bitrate
@@ -328,32 +292,34 @@ export class CbaDataSource implements DataSource {
         : undefined,
       codec: media.media_details.codec,
       duration: media.media_details.length,
-      mimeType: media.mime_type,
+      mimeType: media.mime_type || null,
       cid: null,
       resolution: null,
     }
+
     const asset: form.MediaAssetInput = {
       title: media.title.rendered,
       description: media.description?.rendered,
       mediaType: 'audio',
       duration: media.media_details.length || null,
-      //License: null,
-      //contributor
       Concepts: media.media_tag.map((cbaId) => ({
         uri: this._uri('tag', cbaId),
       })),
       File: { uri: fileId },
     }
+
     const fileEntity: EntityForm = {
       type: 'File',
       content: file,
       entityUris: [fileId],
     }
+
     const mediaEntity: EntityForm = {
       type: 'MediaAsset',
       content: asset,
       entityUris: [audioId],
     }
+
     return [fileEntity, mediaEntity]
   }
 
@@ -361,39 +327,54 @@ export class CbaDataSource implements DataSource {
     const fileId = this._uri('file', media.id)
     const imageId = this._uri('image', media.id)
 
+    if (!media.source_url) {
+      throw new Error('Media source URL is missing.')
+    }
+
+    if (!media.media_details) {
+      throw new Error('Media details are missing.')
+    }
+
     const file: form.FileInput = {
       contentUrl: media.source_url,
       contentSize: media.media_details.filesize || null,
       mimeType: media.mime_type,
       resolution: null,
     }
+
     if (media.media_details.width && media.media_details.height) {
       file.resolution =
         media.media_details.height.toString() +
         'x' +
         media.media_details.width.toString()
     }
+
+    if (!media.title || !media.title.rendered) {
+      throw new Error('Media title is missing.')
+    }
+
     const asset: form.MediaAssetInput = {
       title: media.title.rendered,
       description: media.description?.rendered || null,
       mediaType: 'image',
-      //License: null,
-      //contributor
       Concepts: media.media_tag.map((cbaId) => ({
         uri: this._uri('tag', cbaId),
       })),
       File: { uri: fileId },
     }
+
     const fileEntity: EntityForm = {
       type: 'File',
       content: file,
       entityUris: [fileId],
     }
+
     const mediaEntity: EntityForm = {
       type: 'MediaAsset',
       content: asset,
       entityUris: [imageId],
     }
+
     return [fileEntity, mediaEntity]
   }
 
@@ -404,7 +385,7 @@ export class CbaDataSource implements DataSource {
       kind: ConceptKind.CATEGORY,
       originNamespace: 'https://cba.fro.at/wp-json/wp/v2/categories',
     }
-    if (category.parent) {
+    if (category.parent !== undefined) {
       content.ParentConcept = { uri: this._uri('category', category.parent) }
     }
     const revisionId = this._revisionUri(
@@ -421,6 +402,10 @@ export class CbaDataSource implements DataSource {
   }
 
   private _mapTag(tag: CbaTag): EntityForm[] {
+    if (!tag || !tag.name || !tag.id) {
+      console.error('Invalid tag input.')
+      throw new Error('Invalid tag input.')
+    }
     const content: form.ConceptInput = {
       name: tag.name,
       description: tag.description,
@@ -437,28 +422,42 @@ export class CbaDataSource implements DataSource {
   }
 
   private _mapStation(station: CbaStation): EntityForm[] {
+    if (!station.title || !station.title.rendered) {
+      throw new Error(
+        `Missing or invalid title for station with ID ${station.id}`,
+      )
+    }
+
     const content: form.PublicationServiceInput = {
-      medium: station.type,
-      address: station.link,
+      medium: station.type || '',
+      address: station.link || '',
       name: station.title.rendered,
     }
+
     const revisionId = this._revisionUri(
       'station',
       station.id,
       new Date(station.modified).getTime(),
     )
+
     const uri = this._uri('station', station.id)
+
     const headers = {
       revisionUris: [revisionId],
       entityUris: [uri],
     }
+
     return [{ type: 'PublicationService', content, ...headers }]
   }
 
   private _mapSeries(series: CbaSeries): EntityForm[] {
+    if (!series.title || !series.title.rendered) {
+      throw new Error('Series title is missing.')
+    }
+
     const content: form.ContentGroupingInput = {
       title: series.title.rendered,
-      description: series.content.rendered,
+      description: series.content.rendered || null,
       groupingType: 'show',
       subtitle: null,
       summary: null,
@@ -481,62 +480,67 @@ export class CbaDataSource implements DataSource {
   }
 
   private _mapPost(post: CbaPost): EntityForm[] {
-    const mediaAssetsAndFiles = post._fetchedAttachements
-      .map((attachement) => this._mapAudio(attachement))
-      .flat()
+    try {
+      const mediaAssetsAndFiles = post._fetchedAttachements
+        .map((attachement) => this._mapAudio(attachement))
+        .flat()
 
-    const mediaAssetUris = mediaAssetsAndFiles
-      .filter((entity) => entity.type === 'MediaAsset')
-      .map((x) => x.entityUris || [])
-      .flat()
+      const mediaAssetUris = mediaAssetsAndFiles
+        .filter((entity) => entity.type === 'MediaAsset')
+        .map((x) => x.entityUris || [])
+        .flat()
 
-    const mappedMediaAssets = mediaAssetUris.map((uri) => ({ uri }))
-    mediaAssetUris.forEach((e) => this.fetchByUri(e))
+      const mappedMediaAssets = mediaAssetUris.map((uri) => ({ uri }))
+      mediaAssetUris.forEach((e) => this.fetchByUri(e))
 
-    const featured_image = { uri: this._uri('image', post.featured_image) }
-    mappedMediaAssets.push(featured_image)
+      const featured_image = { uri: this._uri('image', post.featured_image) }
+      mappedMediaAssets.push(featured_image)
 
-    const categories = post.categories.map((cbaId) => ({
-      uri: this._uri('category', cbaId),
-    }))
-    const tags = post.tags.map((cbaId) => ({
-      uri: this._uri('tag', cbaId),
-    }))
-    const conceptsUris = categories.concat(tags)
+      const categories = post.categories.map((cbaId) => ({
+        uri: this._uri('category', cbaId),
+      }))
+      const tags = post.tags.map((cbaId) => ({
+        uri: this._uri('tag', cbaId),
+      }))
+      const conceptsUris = categories.concat(tags)
 
-    const content: form.ContentItemInput = {
-      pubDate: new Date(post.date),
-      content: post.content.rendered,
-      contentFormat: 'text/html',
-      title: post.title.rendered,
-      subtitle: 'missing',
-      summary: post.excerpt.rendered,
-      PublicationService: { uri: this._uri('station', post.meta.station_id) },
-      Concepts: conceptsUris,
-      MediaAssets: mappedMediaAssets,
-      PrimaryGrouping: { uri: this._uri('series', post.post_parent) },
-      //licenseUid
-      //primaryGroupingUid
-      //contributor
-      //AdditionalGroupings
-      //License
-      //BroadcastEvents
+      const content: form.ContentItemInput = {
+        pubDate: new Date(post.date),
+        content: post.content.rendered,
+        contentFormat: 'text/html',
+        title: post.title.rendered,
+        subtitle: 'missing',
+        summary: post.excerpt.rendered,
+        PublicationService: { uri: this._uri('station', post.meta.station_id) },
+        Concepts: conceptsUris,
+        MediaAssets: mappedMediaAssets,
+        PrimaryGrouping: { uri: this._uri('series', post.post_parent) },
+        //licenseUid
+        //primaryGroupingUid
+        //contributor
+        //AdditionalGroupings
+        //License
+        //BroadcastEvents
+      }
+      const revisionId = this._revisionUri(
+        'post',
+        post.id,
+        new Date(post.modified).getTime(),
+      )
+      const entityUri = this._uri('post', post.id)
+
+      const headers = {
+        revisionUris: [revisionId],
+        entityUris: [entityUri],
+      }
+      return [
+        ...mediaAssetsAndFiles,
+        { type: 'ContentItem', content, ...headers },
+      ]
+    } catch (error) {
+      console.error(`Error mapping post with ID ${post.id}:`, error)
+      throw error
     }
-    const revisionId = this._revisionUri(
-      'post',
-      post.id,
-      new Date(post.modified).getTime(),
-    )
-    const entityUri = this._uri('post', post.id)
-
-    const headers = {
-      revisionUris: [revisionId],
-      entityUris: [entityUri],
-    }
-    return [
-      ...mediaAssetsAndFiles,
-      { type: 'ContentItem', content, ...headers },
-    ]
   }
 
   private _url(urlString: string, opts: FetchOpts = {}) {

--- a/packages/repco-core/src/datasources/cba.ts
+++ b/packages/repco-core/src/datasources/cba.ts
@@ -136,7 +136,9 @@ export class CbaDataSource implements DataSource {
     const endpoint = endpointMap[type]
 
     if (!endpoint) {
-      throw new Error('Unsupported CBA data type: ' + parsed.type)
+      throw new Error(
+        `Unsupported data type for ${this.definition.name}: ${parsed.type}`,
+      )
     }
 
     const url = this._url(`/${endpoint}/${id}`)

--- a/packages/repco-core/src/datasources/wpTemplate.ts
+++ b/packages/repco-core/src/datasources/wpTemplate.ts
@@ -1,0 +1,296 @@
+/* This code is an example template that can be used to programmatically create a datasource 
+that comes from a Wordpress API. It provides all the necessary boilerplate code for creating 
+a custom datasource. The code includes type definitions for the datasource, as well as a plugin 
+that can be used to create an instance of the datasource.
+
+The datasource uses the zod library for schema validation and undici for making HTTP requests. 
+The code defines a class called "yourDatasourceDataSource", which implements the DataSource interface. 
+This class has methods for fetching data from the Wordpress API and mapping the results to entity forms.
+
+The code also includes a helper method for parsing URIs that correspond to entities in the Wordpress API, 
+as well as methods for constructing URIs that can be used to fetch data from the API. The plugin defined in 
+the code can be used to create an instance of the datasource, which can then be used to fetch data from the Wordpress API. */
+
+import * as zod from 'zod'
+import { fetch } from 'undici'
+import { yourDatasourcePost } from './wpTemplate/types.js'
+import {
+  DataSource,
+  DataSourceDefinition,
+  DataSourcePlugin,
+  FetchUpdatesResult,
+  SourceRecordForm,
+} from '../datasource.js'
+import { EntityForm } from '../entity.js'
+import { FetchOpts } from '../util/datamapping.js'
+import { HttpError } from '../util/error.js'
+
+// Define default values for the datasource endpoint and the content type
+const DEFAULT_ENDPOINT = 'https://yourDatasource.cat/wp-json/wp/v2'
+const CONTENT_TYPE_JSON = 'application/json'
+
+// Define the shape of objects representing forms
+export type FormsWithUid = {
+  uid: string
+  entities: EntityForm[]
+}
+
+// Define the schema for the datasource configuration
+const configSchema = zod.object({
+  endpoint: zod.string().url().optional(),
+  apiKey: zod.string().optional(),
+})
+// Define the inferred type for the schema
+type ConfigSchema = zod.infer<typeof configSchema>
+
+// Define the plugin for the datasource
+export class yourDatasourceDataSourcePlugin implements DataSourcePlugin {
+  // Create an instance of the datasource
+  createInstance(config: any) {
+    const parsedConfig = configSchema.parse(config)
+    return new yourDatasourceDataSource(parsedConfig)
+  }
+  // Get the definition for the datasource
+  get definition() {
+    return {
+      uid: 'urn:repco:datasource:yourDatasource',
+      name: 'yourDatasource',
+    }
+  }
+}
+
+// Define the datasource
+export class yourDatasourceDataSource implements DataSource {
+  // Define instance variables for the endpoint, endpoint origin, URI prefix, and API key
+  endpoint: string
+  endpointOrigin: string
+  uriPrefix: string
+  apiKey?: string
+
+  // Define the constructor, which takes in a configuration object and sets instance variables
+  constructor(config: ConfigSchema) {
+    // Set the endpoint based on the config or default
+    this.endpoint = config.endpoint || DEFAULT_ENDPOINT
+    // Set the API key based on the config or environment variable or undefined
+    this.apiKey =
+      config.apiKey || process.env.yourDatasource_API_KEY || undefined
+    // Get the origin from the endpoint
+    const endpointUrl = new URL(this.endpoint)
+    this.endpointOrigin = endpointUrl.hostname
+    // Set the URI prefix
+    this.uriPrefix = `repco:yourDatasource:${this.endpointOrigin}`
+  }
+
+  // Define a getter for the configuration object
+  get config() {
+    return { endpoint: this.endpoint, apiKey: this.apiKey }
+  }
+
+  // Define a getter for the datasource definition
+  get definition(): DataSourceDefinition {
+    return {
+      name: 'yourDatasource',
+      uid: 'urn:datasource:yourDatasource:' + this.endpoint,
+      pluginUid: 'urn:repco:datasource:yourDatasource',
+    }
+  }
+
+  // Define a function to check if a URI can be fetched by the datasource
+  canFetchUri(uri: string): boolean {
+    const parsed = this.parseUri(uri)
+    return !!parsed
+  }
+
+  // This method fetches data from your data source by a specified URI.
+  async fetchByUri(uri: string): Promise<SourceRecordForm[]> {
+    // Parse the URI to retrieve the ID and type of data you want to fetch.
+    const parsed = this.parseUri(uri)
+    if (!parsed) {
+      throw new Error('Invalid URI')
+    }
+
+    // Define an endpoint map that maps the data types to endpoint URLs.
+    const endpointMap: { [key: string]: string } = {
+      post: 'yourPostEndpoint',
+    }
+
+    // Retrieve the endpoint URL for the data type from the endpoint map.
+    const { id, type } = parsed
+    const endpoint = endpointMap[type]
+
+    // Throw an error if the data type is not supported.
+    if (!endpoint) {
+      throw new Error(
+        `Unsupported data type for ${this.definition.name}: ${parsed.type}`,
+      )
+    }
+
+    // Construct the URL for the data type.
+    const url = this._url(`/${endpoint}/${id}`)
+    const [body] = await Promise.all([this._fetch(url)])
+
+    // Return an array of source record objects that contain the fetched data.
+    return [
+      {
+        body: JSON.stringify(body),
+        contentType: CONTENT_TYPE_JSON,
+        sourceType: type,
+        sourceUri: url,
+      },
+    ]
+  }
+
+  // Fetches updates for podcasts from a given cursor string and returns a promise containing a `FetchUpdatesResult`.
+  async fetchUpdates(cursorString: string | null): Promise<FetchUpdatesResult> {
+    // Parse cursor string to JSON object
+    const cursor = cursorString ? JSON.parse(cursorString) : {}
+    const { posts: postsCursor = '1970-01-01T01:00:00' } = cursor
+
+    // Set pagination parameters and URL for the API request
+    const perPage = 100
+    const url = this._url(
+      `/podcasts?page=1&per_page=${perPage}&_embed&orderby=modified&order=asc&modified_after=${postsCursor}`,
+    )
+
+    try {
+      // Fetch posts using the URL
+      const posts = await this._fetch<yourDatasourcePost[]>(url)
+
+      // Update cursor with the latest modified date
+      cursor.posts = posts?.[posts.length - 1]?.modified || cursor.posts
+
+      // Return result in a FetchUpdatesResult object
+      return {
+        cursor: JSON.stringify(cursor),
+        records: [
+          {
+            body: JSON.stringify(posts),
+            contentType: CONTENT_TYPE_JSON,
+            sourceType: 'posts',
+            sourceUri: url,
+          },
+        ],
+      }
+    } catch (error) {
+      // Log and re-throw error
+      console.error('Error fetching updates:', error)
+      throw error
+    }
+  }
+
+  // Maps a `SourceRecordForm` to an array of `EntityForm` using the body of the record.
+  async mapSourceRecord(record: SourceRecordForm): Promise<EntityForm[]> {
+    // Parse the body of the record
+    const body = JSON.parse(record.body)
+
+    // Map the body to an array of `EntityForm` depending on the source type
+    switch (record.sourceType) {
+      case 'post':
+        return this._mapPost(body as yourDatasourcePost)
+      default:
+        throw new Error('Unknown source type: ' + record.sourceType)
+    }
+  }
+
+  // Parses a URI string to an object containing the kind, type, and ID of the URI.
+  private parseUri(uri: string) {
+    // Check if the URI string has the correct prefix
+    if (!uri.startsWith(this.uriPrefix + ':')) return null
+
+    // Remove the prefix and split the URI string by the colon separator
+    uri = uri.substring(this.uriPrefix.length + 1)
+    const parts = uri.split(':')
+
+    // Create an object containing the kind, type, and ID based on the parts of the URI string
+    if (parts[0] === 'e') {
+      if (parts.length !== 3) return null
+      return {
+        kind: 'entity',
+        type: parts[1],
+        id: parts[2],
+      }
+    } else if (parts[1] === 'r') {
+      if (parts.length !== 4) return null
+      return {
+        kind: 'revision',
+        type: parts[1],
+        id: parts[2],
+        revisionId: parts[3],
+      }
+    } else {
+      return null
+    }
+  }
+
+  private _uri(type: string, id: string | number): string {
+    return `${this.uriPrefix}:e:${type}:${id}`
+  }
+
+  // This function retrieves the revision URI for a given type, ID, and revision ID in the datasource.
+  private _revisionUri(
+    type: string,
+    id: string | number,
+    revisionId: string | number,
+  ): string {
+    return `${this.uriPrefix}:r:${type}:${id}:${revisionId}`
+  }
+
+  // This function maps a post object from the datasource to an array of entity forms to be sent to the CMS.
+  private _mapPost(post: yourDatasourcePost): EntityForm[] {
+    try {
+      return [
+        {
+          type: 'ContentItem',
+          content: {
+            pubDate: new Date(),
+            content: post.content,
+            contentFormat: 'text/html',
+            title: post.title,
+            subtitle: '',
+            summary: '',
+          },
+          entityUris: [this._uri('post', post.id)],
+          revisionUris: [
+            this._revisionUri(
+              'post',
+              post.id,
+              new Date(post.modified).getTime(),
+            ),
+          ],
+        },
+      ]
+    } catch (error) {
+      console.error('Error in _mapPost:', error)
+      throw error
+    }
+  }
+
+  // This function constructs a URL from a given URL string and fetch options object.
+  private _url(urlString: string, opts: FetchOpts = {}) {
+    const url = new URL(this.endpoint + urlString)
+    if (opts.params) {
+      for (const [key, value] of Object.entries(opts.params)) {
+        url.searchParams.set(key, value)
+      }
+      opts.params = undefined
+    }
+    return url.toString()
+  }
+
+  // This function performs a fetch request with the given URL and fetch options object, returning the JSON response as a Promise.
+  private async _fetch<T = any>(
+    urlString: string,
+    opts: FetchOpts = {},
+  ): Promise<T> {
+    const url = new URL(urlString)
+    if (this.apiKey) {
+      url.searchParams.set('api_key', this.apiKey)
+    }
+    const res = await fetch(url.toString(), opts)
+    if (!res.ok) {
+      throw await HttpError.fromResponseJson(res, url)
+    }
+    const json = await res.json()
+    return json as T
+  }
+}

--- a/packages/repco-core/src/datasources/wpTemplate/types.ts
+++ b/packages/repco-core/src/datasources/wpTemplate/types.ts
@@ -1,0 +1,19 @@
+// this is the type of the data that will be returned from the datasource
+// and just an example typically this would be a json object for a Wordpress
+// datasource Api
+
+export interface yourDatasourcePost {
+  id: number
+  date: Date
+  date_gmt: Date
+  guid: string
+  modified: Date
+  modified_gmt: Date
+  slug: string
+  link: string
+  title: string
+  content: string
+  category: number[]
+  tag: number[]
+  series: number[]
+}

--- a/packages/repco-core/src/datasources/xrcb.ts
+++ b/packages/repco-core/src/datasources/xrcb.ts
@@ -40,21 +40,6 @@ import { ConceptKind, ContentGroupingVariant, EntityForm } from '../entity.js'
 import { FetchOpts } from '../util/datamapping.js'
 import { HttpError } from '../util/error.js'
 
-type ParsedUri =
-  | {
-      kind: string
-      type: string
-      id: string
-      revisionId?: undefined
-    }
-  | {
-      kind: string
-      type: string
-      id: string
-      revisionId: string
-    }
-  | null
-
 /**
  * The default endpoint for the XRCB WordPress API.
  */
@@ -159,7 +144,9 @@ export class XrcbDataSource implements DataSource {
     const endpoint = endpointMap[type]
 
     if (!endpoint) {
-      throw new Error('Unsupported XRCB data type: ' + parsed.type)
+      throw new Error(
+        `Unsupported data type for ${this.definition.name}: ${parsed.type}`,
+      )
     }
 
     const url = this._url(`/${endpoint}/${id}`)


### PR DESCRIPTION
The XRCB datasource should now be functional, and we have made some improvements to CBA. Also added a template/example for implementing a datasource which use wp-api , may usefull for documentation.

**Some notes...**

To Do:
- We need to add error handling for refetching. One possible solution could be to add an error entity to the RDDM, which could help us handle mapping errors as well. Default values are not a good solution in my opinion.

Nice to have:
- XRCB: We should consider adding "Usario" as the contributor for the latest ContentItems. We need to check whether they are the author or editor. @geraldo, can you please verify this?
- CBA: We should consider adding the editor to ContentItems. 
- We should consider adding the image mediaAsset as a teaser image.

Need to Discuss:
- We should consider fetching updates with multiple fetches on different entities. For example, we could fetch posts and series in parallel to improve performance.
- We need to introduce a naming convention on repco side we talk about contentItems on wordpress side about posts so we should decide if we name the datasourceses or their functions from repco or from the datasource for example mapPrimaryGroupings instead of mapCategories or map ContentItems instead of mapPosts. right now we are not consistent 